### PR TITLE
Changing Distribution to inherit from Resource

### DIFF
--- a/src/csvcubedmodels/rdf/dcat.py
+++ b/src/csvcubedmodels/rdf/dcat.py
@@ -92,7 +92,7 @@ class Resource(NewMetadataResource):
 
 
 
-class Distribution(NewMetadataResource):
+class Distribution(Resource):
 
     is_distribution_of: Ann[
         str, Triple(DCAT.isDistributionOf, PropertyStatus.recommended, URIRef)


### PR DESCRIPTION
A simple change to the inheritance of the Distribution model class, it now inherits from Resource instead of NewMetadataResource (which is a superclass of Resource). Inheriting from Resource gives access to more catalog metadata properties that are expected to be populated in csvcubed (catalog.py line 79)